### PR TITLE
Force index use by only looking for beginning of string.

### DIFF
--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -38,7 +38,7 @@ module Winnow
             scoped = scoped.where(name => val)
           elsif contains_scopes.include?(name.to_s)
             column = name.to_s.gsub("_contains", "")
-            scoped = scoped.where("#{table_name}.#{column} like ?", "%#{value}%")
+            scoped = scoped.where("#{table_name}.#{column} like ?", "#{value}%")
           elsif scoped.respond_to?(name)
             scoped = scoped.send(name, value)
           else

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -59,7 +59,7 @@ describe Winnow::Model do
 
     it "should set up contains conditions on any fields defined as contains searchable" do
       User.searchable(:name_contains)
-      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "%ate%")
+      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "ate%")
       User.search(name_contains: "ate")
     end
 


### PR DESCRIPTION
Some searches on Teacher were timing out and giving a blank screen as the search tried to match the entire string and therefor did not use the indexes.  This change looks for the string only at the beginning of the field, uses the index, and should therefor be much faster and avoid the timeout.

See https://github.com/blake-education/blake-admin/pull/512.
