### PR TITLE
revert/allow contains requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ gemfile:
   - gemfiles/rails4013.gemfile
 notifications:
   email:
-    - brad@lucky-dip.net
+    - dev@blake.com.au

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -28,7 +28,6 @@ module Winnow
       # Sets up arel queries for the given params.
       # Anything not defined by a call to #searchable will be ignored.
       def search(all_params)
-        binding.pry
         relevant_params = (all_params || {}).slice(*searchables)
         searchable_params = relevant_params.select {|name, v| v.to_s.present? }
 

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -15,7 +15,7 @@ module Winnow
         missing = names - found
         if missing.any?
           str = missing.map { |s| ":#{s}" }.join(", ")
-          raise RuntimeError.new("Unknown searchable: #{str}")
+          raise_error(str)
         else
           Winnow.add_searchable(self, names)
         end
@@ -45,7 +45,7 @@ module Winnow
           elsif scoped.respond_to?(name)
             scoped = scoped.send(name, value)
           else
-            raise RuntimeError.new("Unknown searchable: #{name}")
+            raise_error(name)
           end
         end
         Winnow::FormObject.new(self, scoped, relevant_params)
@@ -66,6 +66,14 @@ module Winnow
 
       def contains_scopes
         @contains_scopes ||= column_names.map { |name| "#{name}_contains" }.flatten
+      end
+
+      def raise_error(str)
+        if Rails.env.test?
+          puts "\n\n\n\n\nERROR: Unknown searchable: #{str}\n\n\n\n\n"
+        else
+          raise RuntimeError.new("Unknown searchable: #{str}")
+        end
       end
     end
   end

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -15,7 +15,7 @@ module Winnow
         missing = names - found
         if missing.any?
           str = missing.map { |s| ":#{s}" }.join(", ")
-          raise_error(str)
+          raise RuntimeError.new("Unknown searchable: #{str}")
         else
           Winnow.add_searchable(self, names)
         end
@@ -45,7 +45,7 @@ module Winnow
           elsif scoped.respond_to?(name)
             scoped = scoped.send(name, value)
           else
-            raise_error(name)
+            raise RuntimeError.new("Unknown searchable: #{name}")
           end
         end
         Winnow::FormObject.new(self, scoped, relevant_params)
@@ -66,14 +66,6 @@ module Winnow
 
       def contains_scopes
         @contains_scopes ||= column_names.map { |name| "#{name}_contains" }.flatten
-      end
-
-      def raise_error(str)
-        if Rails.env.test?
-          puts "\n\n\n\n\nERROR: Unknown searchable: #{str}\n\n\n\n\n"
-        else
-          raise RuntimeError.new("Unknown searchable: #{str}")
-        end
       end
     end
   end

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -38,6 +38,9 @@ module Winnow
             scoped = scoped.where(name => val)
           elsif contains_scopes.include?(name.to_s)
             column = name.to_s.gsub("_contains", "")
+            scoped = scoped.where("#{table_name}.#{column} like ?", "%#{value}%")
+          elsif starts_with_scopes.include?(name.to_s)
+            column = name.to_s.gsub("_starts_with", "")
             scoped = scoped.where("#{table_name}.#{column} like ?", "#{value}%")
           elsif scoped.respond_to?(name)
             scoped = scoped.send(name, value)
@@ -54,6 +57,10 @@ module Winnow
         column_names.include?(name.to_s) ||
           contains_scopes.include?(name.to_s) ||
           respond_to?(name)
+      end
+
+      def starts_with_scopes
+        @starts_with_scopes ||= column_names.map { |name| "#{name}_starts_with" }.flatten
       end
 
       def contains_scopes

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -28,6 +28,7 @@ module Winnow
       # Sets up arel queries for the given params.
       # Anything not defined by a call to #searchable will be ignored.
       def search(all_params)
+        binding.pry
         relevant_params = (all_params || {}).slice(*searchables)
         searchable_params = relevant_params.select {|name, v| v.to_s.present? }
 
@@ -56,6 +57,7 @@ module Winnow
       def accepted_name?(name)
         column_names.include?(name.to_s) ||
           contains_scopes.include?(name.to_s) ||
+          starts_with_scopes.include?(name.to_s) ||
           respond_to?(name)
       end
 

--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -60,12 +60,12 @@ module Winnow
           respond_to?(name)
       end
 
-      def starts_with_scopes
-        @starts_with_scopes ||= column_names.map { |name| "#{name}_starts_with" }.flatten
-      end
-
       def contains_scopes
         @contains_scopes ||= column_names.map { |name| "#{name}_contains" }.flatten
+      end
+
+      def starts_with_scopes
+        @starts_with_scopes ||= column_names.map { |name| "#{name}_starts_with" }.flatten
       end
     end
   end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Winnow::Model
 
-  scope :name_starts_with, lambda { |str| where("name like ?", "%#{str}") }
+  scope :name_starts_with, lambda { |str| where("name like ?", "#{str}%") }
 
   def self.email_from(domain)
     where("email like '%@?", domain)

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Winnow::Model
 
-  scope :name_starts_with, lambda { |str| where("name like ?", "#{str}%") }
+  scope :name_ends_with, lambda { |str| where("name like ?", "%#{str}") }
 
   def self.email_from(domain)
     where("email like '%@?", domain)

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Winnow::Model
 
-  scope :name_starts_with, lambda { |str| where("name like ?", "#{str}%") }
+  scope :name_starts_with, lambda { |str| where("users.name like ?", "#{str}%") }
 
   def self.email_from(domain)
     where("email like '%@?", domain)

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include Winnow::Model
 
-  scope :name_starts_with, lambda { |str| where("users.name like ?", "#{str}%") }
+  scope :name_starts_with, lambda { |str| where("name like ?", "#{str}%") }
 
   def self.email_from(domain)
     where("email like '%@?", domain)

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -64,8 +64,8 @@ describe Winnow::Model do
     end
 
     it "should set up starts_with conditions on any fields defined as starts_with searchable" do
-      User.searchable(:name_starts_with)
-      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "Pete%")
+      User.searchable(:login_starts_with)
+      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.login like ?", "Pete%")
       User.search(name_contains: "Pete")
     end
 

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -40,9 +40,9 @@ describe Winnow::Model do
 
   describe ".search" do
     it "should call any class methods defined as searchable" do
-      User.searchable(:name_starts_with)
-      User.should_receive(:name_starts_with).with("Joelle").and_call_original
-      User.search(name_starts_with: "Joelle")
+      User.searchable(:login_starts_with)
+      User.should_receive(:login_starts_with).with("Joelle").and_call_original
+      User.search(login_starts_with: "Joelle")
     end
 
     it "should call any scopes defined as searchable" do
@@ -66,7 +66,7 @@ describe Winnow::Model do
     it "should set up starts_with conditions on any fields defined as starts_with searchable" do
       User.searchable(:login_starts_with)
       ActiveRecord::Relation.any_instance.should_receive(:where).with("users.login like ?", "Pete%")
-      User.search(name_contains: "Pete")
+      User.search(login_starts_with: "Pete")
     end
 
     it "should call all searchables if multiple params passed in" do

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -59,8 +59,14 @@ describe Winnow::Model do
 
     it "should set up contains conditions on any fields defined as contains searchable" do
       User.searchable(:name_contains)
-      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "ate%")
+      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "%ate%")
       User.search(name_contains: "ate")
+    end
+
+    it "should set up starts_with conditions on any fields defined as starts_with searchable" do
+      User.searchable(:name_starts_with)
+      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "Pete%")
+      User.search(name_contains: "Pete")
     end
 
     it "should call all searchables if multiple params passed in" do

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -40,9 +40,9 @@ describe Winnow::Model do
 
   describe ".search" do
     it "should call any class methods defined as searchable" do
-      User.searchable(:login_starts_with)
-      User.should_receive(:login_starts_with).with("Joelle").and_call_original
-      User.search(login_starts_with: "Joelle")
+      User.searchable(:name_starts_with)
+      User.should_receive(:name_starts_with).with("Joelle").and_call_original
+      User.search(name_starts_with: "Joelle")
     end
 
     it "should call any scopes defined as searchable" do
@@ -64,9 +64,9 @@ describe Winnow::Model do
     end
 
     it "should set up starts_with conditions on any fields defined as starts_with searchable" do
-      User.searchable(:login_starts_with)
-      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.login like ?", "Pete%")
-      User.search(login_starts_with: "Pete")
+      User.searchable(:name_starts_with)
+      ActiveRecord::Relation.any_instance.should_receive(:where).with("users.name like ?", "Pete%")
+      User.search(name_starts_with: "Pete")
     end
 
     it "should call all searchables if multiple params passed in" do

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -40,9 +40,9 @@ describe Winnow::Model do
 
   describe ".search" do
     it "should call any class methods defined as searchable" do
-      User.searchable(:name_starts_with)
-      User.should_receive(:name_starts_with).with("Joelle")
-      User.search(name_starts_with: "Joelle")
+      User.searchable(:name_ends_with)
+      User.should_receive(:name_ends_with).with("Joelle").and_call_original
+      User.search(name_ends_with: "Joelle")
     end
 
     it "should call any scopes defined as searchable" do

--- a/spec/winnow/model_spec.rb
+++ b/spec/winnow/model_spec.rb
@@ -41,7 +41,7 @@ describe Winnow::Model do
   describe ".search" do
     it "should call any class methods defined as searchable" do
       User.searchable(:name_starts_with)
-      User.should_receive(:name_starts_with).with("Joelle").and_call_original
+      User.should_receive(:name_starts_with).with("Joelle")
       User.search(name_starts_with: "Joelle")
     end
 

--- a/winnow.gemspec
+++ b/winnow.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 3.0.0"
+  s.add_dependency "rails", [">= 3.0.0", "< 5"]
 
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
- [ ] Contains migration(s)?
- [ ] Indices added?
- [ ] Documentation added for new code?
- [ ] Documentation added and reviewed for refactored code?
- [ ] Signed off by DevOps (as required)
#### What does this PR do?

Reverts change made in this PR: https://github.com/blake-education/winnow/pull/8
Also adds additional check for "starts_with"
#### How should this be manually tested?

Running the included specs
#### Any background context you want to provide?

Original change was made as "contains" searches were timing out. See trello ticket for more background.
#### What are the relevant tickets?

https://trello.com/c/7UvIq4ne/229-tidy-up-search-fix-allow-searching-email-field-with-contains
#### What are the related PRs?

https://github.com/blake-education/blake-admin/pull/565
#### Any special deployment instructions?
#### Screenshots
#### Anything left to do?

@blake-education/customer-service 
