### PR TITLE
feat: add support for trilogy mysql adapter.

### DIFF
--- a/lib/winnow/model.rb
+++ b/lib/winnow/model.rb
@@ -69,7 +69,7 @@ module Winnow
 
       def connection_adapter
         case connection.adapter_name
-        when /mysql/i
+        when /(?:mysql|trilogy)/i
           :mysql
         when /postgres/i
           :postgres


### PR DESCRIPTION
see https://3plearning.slack.com/archives/C01QPALDB2N/p1706744994907279


Tested on Admin

```
[2] pry(main)> Student.search({first_name_starts_with: "fleet"}).first; 1
  Student Load (1.1ms)  /*application:BlakeAdmin*/ SELECT `students`.* FROM `students` WHERE `students`.`deleted_at` IS NULL AND ((match(students.first_name) against('+fleet*' in boolean mode) and (students.first_name like 'fleet%'))) ORDER BY `students`.`id` ASC LIMIT 1
=> 1
```